### PR TITLE
Patch wrong header colours on initial load

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,4 +1,4 @@
-import { Box, Container, Heading, Image, Text, useColorMode, useThemeUI } from 'theme-ui'
+import { Box, Container, Heading, Image, Text, useColorMode } from 'theme-ui'
 import Link from './Link'
 import ColorSwitcher from './color-switcher'
 import { Author, PostTags } from './Post'


### PR DESCRIPTION
https://github.com/user-attachments/assets/8f0a412d-c1db-4908-adb8-79c12775ee2c

I've been fighting this for about an hour and I can't figure out a better fix then this. I think this is the actual issue: https://github.com/system-ui/theme-ui/issues/1602. 

