### PR TITLE
Fix announcement post links to be MD links

### DIFF
--- a/content/posts/organization-announcements/post.mdx
+++ b/content/posts/organization-announcements/post.mdx
@@ -15,9 +15,9 @@ We've launched <b>Organization Announcements</b> to help you send out announceme
 You'll now be able to:
 - 👥 Have people follow your organization with the Follow button located on your Transactions and Announcements pages
 - 📣 Send out announcements using a rich-text editor and blocks that include data from HCB
-- 🗒️ See announcements on the new <a href="https://hcb.hackclub.com/my/feed">Feed</a> page, and receive them in your email inbox.
+- 🗒️ See announcements on the new [Feed](https://hcb.hackclub.com/my/feed) page, and receive them in your email inbox.
 
-Announcements are automatically enabled for transparent organizations. If your organization is not in <a href="https://blog.hcb.hackclub.com/posts/transparent-finances-optional-feature-151427">Transparency Mode</a>, you can still post announcements and get followers by sharing a link to your announcements page. For non-transparent organizations, your announcements page will not be publicly accessible until you publish your first announcement.
+Announcements are automatically enabled for transparent organizations. If your organization is not in [Transparency Mode](https://blog.hcb.hackclub.com/posts/transparent-finances-optional-feature-151427), you can still post announcements and get followers by sharing a link to your announcements page. For non-transparent organizations, your announcements page will not be publicly accessible until you publish your first announcement.
 
 Want to try it out? HCB has already published their first announcement, so go follow us at [hcb.hackclub.com/bank/announcements](https://hcb.hackclub.com/bank/announcements)!
 


### PR DESCRIPTION
The blog doesn't style <a> tags directly, instead applying it directly to the HTML generated from the markdown parsing. Changes the <a> links in the announcement post to be markdown links to be styled.