### PR TITLE
Monthly announcements

### DIFF
--- a/content/posts/monthly-announcements/post.mdx
+++ b/content/posts/monthly-announcements/post.mdx
@@ -15,4 +15,4 @@ By default, each announcement includes summarized data about your organization f
 
 With monthly announcements, HCB will help you build your community by keeping fans and donors informed, while you focus on making your organization awesome! ✨
 
-<img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/50c518d8c25f116116161e4d507b85ea5c52b133_pawelzmarlak-2025-10-27T21_49_44.330Z.png" width="400px" />
+<img src="https://hc-cdn.hel1.your-objectstorage.com/s/v3/79bf9372b46b0388267f4c2413afb311f567abf4_image.png" width="400px" />


### PR DESCRIPTION
#94 only announced organization announcements (tier 1/2), and didn't explain monthly announcements. Now that monthly announcements are more polished, let's add a blog post to explain it!