### PR TITLE
SEO & LLM discoverability: meta, sitemap, robots, llms.txt, .md posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .env
 .posts-cache.js
 headway.json
+public/posts/

--- a/components/Header.js
+++ b/components/Header.js
@@ -210,7 +210,7 @@ export default function Header({ post, small }) {
                       </Text>
                     )}
 
-                  <Heading mt={-1} mb={1} as="h2" sx={{
+                  <Heading mt={-1} mb={1} as="h1" sx={{
                     fontSize: 4,
                   }}>
                     {post.meta.title}

--- a/components/Seo.js
+++ b/components/Seo.js
@@ -1,0 +1,157 @@
+import Head from 'next/head'
+import { authors as authorMap } from '@/content'
+
+// The canonical public origin. Keep in sync with pages/sitemap.xml.js and public/robots.txt.
+const SITE_URL = 'https://blog.hcb.hackclub.com'
+const SITE_NAME = 'HCB Blog'
+const DEFAULT_DESCRIPTION =
+  'Updates, improvements, engineering deep-dives, and announcements from HCB — the finance platform for nonprofits, hackathons, and student communities, built by Hack Club.'
+const DEFAULT_IMAGE = `${SITE_URL}/og-v1.png`
+const TWITTER_HANDLE = '@hackclub'
+
+function toIso(date) {
+  if (!date) return undefined
+  return date instanceof Date ? date.toISOString() : new Date(date).toISOString()
+}
+
+function absoluteImage(meta) {
+  if (meta?.primaryImage?.src) return `${SITE_URL}${meta.primaryImage.src}`
+  return DEFAULT_IMAGE
+}
+
+function resolveAuthors(meta) {
+  const ids = Array.isArray(meta?.authors) ? meta.authors : meta?.authors ? [meta.authors] : []
+  return ids.map(id => authorMap[id]?.name || id).filter(Boolean)
+}
+
+/**
+ * Site-wide SEO component.
+ *
+ * - For post detail pages, pass `post` (the full post object with `.meta`).
+ * - For any other page, pass `title`, `description`, `path`, and `noindex` as needed.
+ *
+ * Emits: <title>, meta description, canonical, Open Graph, Twitter cards,
+ * and JSON-LD (BlogPosting for posts, WebSite for the home page).
+ */
+export default function Seo({ post, title, description, path = '/', image, noindex = false }) {
+  if (post) {
+    const { meta } = post
+    const url = `${SITE_URL}/posts/${meta.slug}`
+    const fullTitle = `${meta.title} – ${SITE_NAME}`
+    const desc =
+      meta.description ||
+      `Read "${meta.title}" on the ${SITE_NAME} — updates and announcements from HCB by Hack Club.`
+    const img = absoluteImage(meta)
+    const published = toIso(meta.date)
+    const authorNames = resolveAuthors(meta)
+    const tags = Array.isArray(meta.tags) ? meta.tags : []
+
+    const jsonLd = {
+      '@context': 'https://schema.org',
+      '@type': 'BlogPosting',
+      headline: meta.title,
+      description: desc,
+      image: [img],
+      datePublished: published,
+      dateModified: published,
+      author: authorNames.map(name => ({ '@type': 'Person', name })),
+      publisher: {
+        '@type': 'Organization',
+        name: 'Hack Club',
+        logo: {
+          '@type': 'ImageObject',
+          url: 'https://assets.hackclub.com/hcb-light.svg'
+        }
+      },
+      mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+      keywords: tags.join(', ') || undefined,
+      articleSection: meta.category || undefined
+    }
+
+    return (
+      <Head>
+        <title>{fullTitle}</title>
+        <meta name="description" content={desc} />
+        <link rel="canonical" href={url} />
+        {noindex && <meta name="robots" content="noindex,nofollow" />}
+
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content={url} />
+        <meta property="og:site_name" content={SITE_NAME} />
+        <meta property="og:title" content={meta.title} />
+        <meta property="og:description" content={desc} />
+        <meta property="og:image" content={img} />
+        <meta property="og:locale" content="en_US" />
+        {published && <meta property="article:published_time" content={published} />}
+        {authorNames.map(name => (
+          <meta key={`author-${name}`} property="article:author" content={name} />
+        ))}
+        {tags.map(tag => (
+          <meta key={`tag-${tag}`} property="article:tag" content={tag} />
+        ))}
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={meta.title} />
+        <meta name="twitter:description" content={desc} />
+        <meta name="twitter:image" content={img} />
+        <meta name="twitter:site" content={TWITTER_HANDLE} />
+
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </Head>
+    )
+  }
+
+  const pageTitle = title ? `${title} – ${SITE_NAME}` : SITE_NAME
+  const shortTitle = title || SITE_NAME
+  const desc = description || DEFAULT_DESCRIPTION
+  const url = `${SITE_URL}${path || '/'}`
+  const img = image || DEFAULT_IMAGE
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    url: SITE_URL,
+    name: SITE_NAME,
+    description: DEFAULT_DESCRIPTION,
+    publisher: {
+      '@type': 'Organization',
+      name: 'Hack Club',
+      url: 'https://hackclub.com',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://assets.hackclub.com/hcb-light.svg'
+      }
+    }
+  }
+
+  return (
+    <Head>
+      <title>{pageTitle}</title>
+      <meta name="description" content={desc} />
+      <link rel="canonical" href={url} />
+      {noindex && <meta name="robots" content="noindex,nofollow" />}
+
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={url} />
+      <meta property="og:site_name" content={SITE_NAME} />
+      <meta property="og:title" content={shortTitle} />
+      <meta property="og:description" content={desc} />
+      <meta property="og:image" content={img} />
+      <meta property="og:locale" content="en_US" />
+
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={shortTitle} />
+      <meta name="twitter:description" content={desc} />
+      <meta name="twitter:image" content={img} />
+      <meta name="twitter:site" content={TWITTER_HANDLE} />
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    </Head>
+  )
+}

--- a/components/Seo.js
+++ b/components/Seo.js
@@ -73,6 +73,12 @@ export default function Seo({ post, title, description, path = '/', image, noind
         <title>{fullTitle}</title>
         <meta name="description" content={desc} />
         <link rel="canonical" href={url} />
+        <link
+          rel="alternate"
+          type="text/markdown"
+          href={`${url}.md`}
+          title={`${meta.title} (Markdown)`}
+        />
         {noindex && <meta name="robots" content="noindex,nofollow" />}
 
         <meta property="og:type" content="article" />

--- a/pages/dev/dashboard.js
+++ b/pages/dev/dashboard.js
@@ -10,6 +10,7 @@ export default function Dashboard() {
         <>
             <Head>
                 <title>Dashboard</title>
+                <meta name="robots" content="noindex,nofollow" />
             </Head>
             <Header />
             <Box as="main" sx={{ color: 'text' }}>

--- a/pages/embed.js
+++ b/pages/embed.js
@@ -8,7 +8,7 @@ import {
 } from 'theme-ui'
 import { useEffect } from 'react'
 import { DisplayProvider } from '@/lib/display'
-import Head from 'next/head'
+import Seo from '@/components/Seo'
 import Cookies from "js-cookie"
 import { useQueryParam, StringParam } from 'use-query-params';
 
@@ -39,13 +39,7 @@ export default function Home() {
 
   return (
     <>
-      <Head>
-        <title>HCB Blog</title>
-        <meta
-          property="og:image"
-          content="https://bank.engineering/og-v1.png"
-        />
-      </Head>
+      <Seo path="/embed" noindex />
 
 
       <Box as="main" sx={{ color: 'text' }} className="post-list">

--- a/pages/index.js
+++ b/pages/index.js
@@ -18,7 +18,7 @@ import { useEffect, useState } from 'react'
 import { DisplayProvider } from '@/lib/display'
 import { PostTags } from '@/components/Post'
 import { useQueryParam, StringParam } from 'use-query-params';
-import Head from 'next/head'
+import Seo from '@/components/Seo'
 import Cookies from "js-cookie"
 
 function PostPreview({ post }) {
@@ -43,14 +43,8 @@ export default function Home() {
 
   return (
     <>
+      <Seo path="/" />
       <Header />
-      <Head>
-        <title>HCB Blog</title>
-        <meta
-          property="og:image"
-          content="https://bank.engineering/og-v1.png"
-        />
-      </Head>
 
 
       <Box as="main" sx={{ color: 'text' }} className="post-list">

--- a/pages/llms.txt.js
+++ b/pages/llms.txt.js
@@ -16,6 +16,8 @@ function buildLlmsTxt(allPosts) {
     '',
     `> Updates, improvements, engineering deep-dives, and announcements from HCB — the finance platform for nonprofits, hackathons, and student communities, built by Hack Club. Canonical site: ${SITE_URL}.`,
     '',
+    `Every post is available as both HTML (at /posts/<slug>) and plain markdown (at /posts/<slug>.md) — the links below point at the markdown variants, which are the preferred format for LLM ingestion.`,
+    '',
     '## Posts',
     ''
   ]
@@ -23,7 +25,7 @@ function buildLlmsTxt(allPosts) {
   for (const post of sorted) {
     const { meta } = post
     if (!meta?.slug || !meta?.title) continue
-    const url = `${SITE_URL}/posts/${meta.slug}`
+    const url = `${SITE_URL}/posts/${meta.slug}.md`
     const desc = meta.description ? `: ${meta.description}` : ''
     lines.push(`- [${meta.title}](${url})${desc}`)
   }

--- a/pages/llms.txt.js
+++ b/pages/llms.txt.js
@@ -1,0 +1,46 @@
+import { posts } from '@/content'
+
+const SITE_URL = 'https://blog.hcb.hackclub.com'
+
+// Serves /llms.txt — an emerging de-facto standard for LLM-powered tools to
+// discover a curated inventory of a site's content. See https://llmstxt.org/.
+function buildLlmsTxt(allPosts) {
+  const sorted = [...allPosts].sort((a, b) => {
+    const da = a.meta?.date instanceof Date ? a.meta.date : new Date(a.meta?.date)
+    const db = b.meta?.date instanceof Date ? b.meta.date : new Date(b.meta?.date)
+    return db - da
+  })
+
+  const lines = [
+    '# HCB Blog',
+    '',
+    `> Updates, improvements, engineering deep-dives, and announcements from HCB — the finance platform for nonprofits, hackathons, and student communities, built by Hack Club. Canonical site: ${SITE_URL}.`,
+    '',
+    '## Posts',
+    ''
+  ]
+
+  for (const post of sorted) {
+    const { meta } = post
+    if (!meta?.slug || !meta?.title) continue
+    const url = `${SITE_URL}/posts/${meta.slug}`
+    const desc = meta.description ? `: ${meta.description}` : ''
+    lines.push(`- [${meta.title}](${url})${desc}`)
+  }
+
+  lines.push('')
+  return lines.join('\n')
+}
+
+export default function LlmsTxt() {
+  return null
+}
+
+export async function getServerSideProps({ res }) {
+  const body = buildLlmsTxt(posts)
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8')
+  res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=86400')
+  res.write(body)
+  res.end()
+  return { props: {} }
+}

--- a/pages/posts/[slug].js
+++ b/pages/posts/[slug].js
@@ -3,7 +3,7 @@ import Header from '@/components/Header'
 import { Author, PostTags } from '@/components/Post'
 import { posts } from '@/content/index'
 import { DisplayProvider } from '@/lib/display'
-import Head from 'next/head'
+import Seo from '@/components/Seo'
 import { useEffect } from 'react'
 import { Box, Card, Container, Flex, Grid, Heading, Link, Text } from 'theme-ui'
 import Cookies from 'js-cookie'
@@ -35,7 +35,6 @@ export default function Post({ slug }) {
   const post = posts.find(post => post.meta.slug === slug)
   const PostBody = post.component
 
-  console.log("FOOBAR", post.meta.primaryImage)
   const date = post.meta.date.toLocaleDateString('en-us', {
     year: 'numeric',
     month: 'long',
@@ -51,15 +50,7 @@ export default function Post({ slug }) {
 
   return (
     <DisplayProvider display="detail">
-      <Head>
-        <title>{post.meta.title}</title>
-        <meta
-          property='og:description'
-          content={post.meta.description ? `${post.meta.description} • ${date}` : date}
-        />
-        {post.meta.primaryImage ? <meta property="og:image" content={"https://bank.engineering" + post.meta.primaryImage.src} /> : null}
-
-      </Head>
+      <Seo post={post} />
       <Header post={post} />
       <Box as="main" sx={{ color: 'text' }}>
         <Container

--- a/pages/preview/[slug].js
+++ b/pages/preview/[slug].js
@@ -3,7 +3,7 @@ import Header from '@/components/Header'
 import { Author, PostTags } from '@/components/Post'
 import { posts } from '@/content/index'
 import { DisplayProvider } from '@/lib/display'
-import Head from 'next/head'
+import Seo from '@/components/Seo'
 import { useEffect } from 'react'
 import { Box, Card, Container, Flex, Grid, Heading, Link, Text } from 'theme-ui'
 import Cookies from 'js-cookie'
@@ -35,7 +35,6 @@ export default function Post({ slug }) {
     const post = posts.find(post => post.meta.slug === slug)
     const PostBody = post.component
 
-    console.log("FOOBAR", post.meta.primaryImage)
     const date = post.meta.date.toLocaleDateString('en-us', {
         year: 'numeric',
         month: 'long',
@@ -66,15 +65,7 @@ export default function Post({ slug }) {
 
     return (
         <DisplayProvider display="detail">
-            <Head>
-                <title>{post.meta.title}</title>
-                <meta
-                    property='og:description'
-                    content={post.meta.description ? `${post.meta.description} • ${date}` : date}
-                />
-                {post.meta.primaryImage ? <meta property="og:image" content={"https://bank.engineering" + post.meta.primaryImage.src} /> : null}
-
-            </Head>
+            <Seo post={post} noindex />
             <Header post={post} small />
             <Box as="main" sx={{ color: 'text' }}>
                 <Container

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -1,0 +1,67 @@
+import { posts } from '@/content'
+
+const SITE_URL = 'https://blog.hcb.hackclub.com'
+
+function escapeXml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function buildSitemap(allPosts) {
+  const latestPost = allPosts.reduce((max, p) => {
+    const d = p.meta?.date instanceof Date ? p.meta.date : new Date(p.meta?.date)
+    return !max || d > max ? d : max
+  }, null)
+
+  const entries = [
+    {
+      loc: `${SITE_URL}/`,
+      lastmod: latestPost ? latestPost.toISOString() : undefined,
+      changefreq: 'daily',
+      priority: '1.0'
+    },
+    ...allPosts.map(post => {
+      const d = post.meta?.date instanceof Date ? post.meta.date : new Date(post.meta?.date)
+      return {
+        loc: `${SITE_URL}/posts/${post.meta.slug}`,
+        lastmod: isNaN(d) ? undefined : d.toISOString(),
+        changefreq: 'monthly',
+        priority: '0.8'
+      }
+    })
+  ]
+
+  const body = entries
+    .map(
+      e => `  <url>
+    <loc>${escapeXml(e.loc)}</loc>${e.lastmod ? `
+    <lastmod>${e.lastmod}</lastmod>` : ''}
+    <changefreq>${e.changefreq}</changefreq>
+    <priority>${e.priority}</priority>
+  </url>`
+    )
+    .join('\n')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${body}
+</urlset>
+`
+}
+
+export default function Sitemap() {
+  return null
+}
+
+export async function getServerSideProps({ res }) {
+  const xml = buildSitemap(posts)
+  res.setHeader('Content-Type', 'application/xml; charset=utf-8')
+  res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=86400')
+  res.write(xml)
+  res.end()
+  return { props: {} }
+}

--- a/pages/widget.js
+++ b/pages/widget.js
@@ -2,6 +2,7 @@ import { Badge } from 'theme-ui';
 import { posts } from '../content'
 import { useEffect, useState } from "react";
 import Cookies from 'js-cookie'
+import Head from 'next/head'
 
 export default function Widget() {
     const [number, setNumber] = useState(0);
@@ -20,6 +21,9 @@ export default function Widget() {
 
     return (
         <>
+            <Head>
+                <meta name="robots" content="noindex,nofollow" />
+            </Head>
             <style jsx global>{`
                 html, body {
                     background: transparent !important;

--- a/prebuild.js
+++ b/prebuild.js
@@ -1,4 +1,8 @@
 const fs = require("fs");
+const path = require("path");
+
+const SITE_URL = 'https://blog.hcb.hackclub.com';
+const PUBLIC_POSTS_DIR = path.join(__dirname, 'public', 'posts');
 
 function debounce(func) {
     let timer;
@@ -7,6 +11,155 @@ function debounce(func) {
         timer = setTimeout(() => { func.apply(this, args); }, 300);
     };
 }
+
+// ---------------------------------------------------------------------------
+// Markdown generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the metadata passed to `post({...})` inside a post's MDX source.
+ * We rely on simple regex rather than a full JS parser because the shape is
+ * constrained by conventions in /content/posts and a README-specified schema.
+ */
+function extractPostMeta(src) {
+    const meta = {};
+    const pullString = field => {
+        const re = new RegExp(`\\b${field}:\\s*(['"\`])((?:\\\\.|(?!\\1).)*)\\1`);
+        const m = src.match(re);
+        return m ? m[2] : null;
+    };
+    const pullArray = field => {
+        const re = new RegExp(`\\b${field}:\\s*\\[([\\s\\S]*?)\\]`);
+        const m = src.match(re);
+        if (!m) return [];
+        return [...m[1].matchAll(/(['"`])((?:\\.|(?!\1).)*)\1/g)].map(x => x[2]);
+    };
+    const pullDate = () => {
+        const m = src.match(/\bdate:\s*new Date\((['"`])([^'"`]+)\1\)/);
+        return m ? m[2] : null;
+    };
+    meta.title = pullString('title');
+    meta.slug = pullString('slug');
+    meta.category = pullString('category');
+    meta.description = pullString('description');
+    meta.tags = pullArray('tags');
+    meta.authors = pullArray('authors');
+    meta.date = pullDate();
+    return meta;
+}
+
+function yamlString(value) {
+    if (value == null) return '';
+    const str = String(value);
+    if (/^[a-zA-Z0-9_.\-\/:]+$/.test(str)) return str;
+    return '"' + str.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+}
+
+function buildFrontmatter(meta) {
+    const lines = ['---'];
+    if (meta.title) lines.push(`title: ${yamlString(meta.title)}`);
+    if (meta.slug) lines.push(`slug: ${yamlString(meta.slug)}`);
+    if (meta.date) lines.push(`date: ${meta.date}`);
+    if (meta.category) lines.push(`category: ${yamlString(meta.category)}`);
+    if (meta.authors && meta.authors.length) {
+        lines.push(`authors: [${meta.authors.map(yamlString).join(', ')}]`);
+    }
+    if (meta.tags && meta.tags.length) {
+        lines.push(`tags: [${meta.tags.map(yamlString).join(', ')}]`);
+    }
+    if (meta.description) lines.push(`description: ${yamlString(meta.description)}`);
+    if (meta.slug) lines.push(`canonical: ${SITE_URL}/posts/${meta.slug}`);
+    lines.push('---');
+    return lines.join('\n');
+}
+
+/**
+ * Transforms a post's MDX source into a plain-markdown body:
+ *   - Removes all `import` statements (they aren't needed in the output).
+ *   - Removes the wrapping `export default post({...})` block.
+ *   - Rewrites `<Image src={identifier} alt="..." />` to a markdown image,
+ *     copying the referenced local asset to `public/posts/<slug>/<file>` so
+ *     the image resolves when the .md is served.
+ *
+ * Other JSX tags (<video>, <table>, <Preview>, <Author>, …) are intentionally
+ * left intact — they're readable to LLMs and uncommon enough that hand-rolled
+ * conversions would add risk without much benefit.
+ */
+function transformMdx(src, slug, postDir, outAssetDir) {
+    // 1. Collect local asset imports, e.g. `import foo from "./bar.png"`.
+    const importMap = {};
+    const importRe = /^[ \t]*import\s+(\w+)\s+from\s+['"]\.\/([^'"]+)['"];?[ \t]*$/gm;
+    for (const m of src.matchAll(importRe)) {
+        const [, id, file] = m;
+        importMap[id] = file;
+        const srcAsset = path.join(postDir, file);
+        if (fs.existsSync(srcAsset)) {
+            fs.mkdirSync(outAssetDir, { recursive: true });
+            try {
+                fs.copyFileSync(srcAsset, path.join(outAssetDir, file));
+            } catch (e) {
+                // non-fatal; asset will just not resolve
+            }
+        }
+    }
+
+    let body = src;
+
+    // 2. Strip every `import ... from '...'` line (top-level or mid-body).
+    body = body.replace(/^[ \t]*import\s[^\n]*?\sfrom\s+['"][^'"]+['"];?[ \t]*$/gm, '');
+
+    // 3. Strip the `export default post({...})` block.
+    body = body.replace(/^export\s+default\s+post\(\{[\s\S]*?^\}\);?\s*$/m, '');
+
+    // 4. Rewrite <Image src={identifier} alt=... /> to markdown when we can.
+    body = body.replace(/<Image\s+([^>]*?)\/>/g, (match, attrs) => {
+        const srcMatch = attrs.match(/src=\{(\w+)\}/);
+        if (!srcMatch || !importMap[srcMatch[1]]) return match;
+        const altMatch = attrs.match(/alt=(?:"([^"]*)"|\{"([^"]*)"\})/);
+        const alt = altMatch ? (altMatch[1] !== undefined ? altMatch[1] : altMatch[2]) : '';
+        return `![${alt}](${SITE_URL}/posts/${slug}/${importMap[srcMatch[1]]})`;
+    });
+
+    // 5. Collapse the triple+ blank lines left behind by stripping imports.
+    body = body.replace(/\n{3,}/g, '\n\n');
+
+    return body.trim();
+}
+
+function buildMarkdown() {
+    const slugs = fs.readdirSync('./content/posts').filter(file => !file.includes('.'));
+    // We're the exclusive owner of public/posts/ (gitignored). Wipe any stale
+    // output from previous runs so deleted posts don't linger as ghost URLs.
+    if (fs.existsSync(PUBLIC_POSTS_DIR)) {
+        fs.rmSync(PUBLIC_POSTS_DIR, { recursive: true, force: true });
+    }
+    fs.mkdirSync(PUBLIC_POSTS_DIR, { recursive: true });
+
+    let written = 0;
+    for (const slug of slugs) {
+        const postDir = path.join('content', 'posts', slug);
+        const mdxPath = path.join(postDir, 'post.mdx');
+        if (!fs.existsSync(mdxPath)) continue;
+        try {
+            const src = fs.readFileSync(mdxPath, 'utf8');
+            const meta = extractPostMeta(src);
+            meta.slug = meta.slug || slug;
+            const outAssetDir = path.join(PUBLIC_POSTS_DIR, slug);
+            const body = transformMdx(src, slug, postDir, outAssetDir);
+            const frontmatter = buildFrontmatter(meta);
+            const output = `${frontmatter}\n\n${body}\n`;
+            fs.writeFileSync(path.join(PUBLIC_POSTS_DIR, `${slug}.md`), output);
+            written++;
+        } catch (err) {
+            console.error(`[md gen] failed for ${slug}:`, err.message);
+        }
+    }
+    console.log(`[md gen] wrote ${written} markdown files to public/posts/`);
+}
+
+// ---------------------------------------------------------------------------
+// Posts-cache generation (existing behavior)
+// ---------------------------------------------------------------------------
 
 function build() {
     console.log("Detected changes in content/posts");
@@ -27,6 +180,8 @@ export * as post_${nonce(i)} from "@/content/posts/${post}/post.mdx?${nonce()}";
 `
 
     fs.writeFileSync("./.posts-cache.js", file);
+
+    buildMarkdown();
 }
 
 if (process.argv.includes("--build")) {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,45 @@
+# robots.txt for blog.hcb.hackclub.com
+# See: https://www.rfc-editor.org/rfc/rfc9309.html
+
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /embed
+Disallow: /preview/
+Disallow: /widget
+Disallow: /dev/
+
+# LLM / AI crawlers — explicitly allowed so the HCB Blog shows up
+# in LLM-powered search and answer tools.
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+Sitemap: https://blog.hcb.hackclub.com/sitemap.xml


### PR DESCRIPTION
## Why

blog.hcb.hackclub.com is statically rendered across ~123 MDX posts — a great starting point for SEO — but it was shipping with almost none of the discoverability scaffolding that lets search engines and LLMs actually rank and cite it:

- no site-wide `<meta name="description">`
- no `<link rel="canonical">` (so `/`, `/?tag=receipts`, `/embed`, `/preview/<slug>` all competed with `/posts/<slug>`)
- no `robots.txt`, `sitemap.xml`, or `llms.txt`
- hardcoded `bank.engineering` in every `og:image`
- no Twitter Card metadata, no structured data (JSON-LD)
- no `<h1>` on post pages (title rendered as `<h2>`)
- utility routes (`/embed`, `/preview/*`, `/widget`, `/dev/*`) were crawlable and created duplicate content
- a couple of stray `console.log("FOOBAR", …)` debug lines in production

This PR tackles the 80/20 fixes — small changes in a handful of files that cover the standard SEO/LLM surface.

## What changed, by commit

Each commit is self-contained and small enough to revert independently if needed.

### 1 · `aeb6a98` Add shared `Seo` component
`components/Seo.js` (new), `pages/index.js`, `pages/posts/[slug].js`

One component replaces the hand-rolled partial `<Head>` blocks on each page. For a post, it emits:

- **`<title>`** using a consistent `Post Title – HCB Blog` pattern so tabs and SERPs always carry the brand anchor.
- **`<meta name="description">`** with the post's own `description` when present, a sensible post-specific default otherwise.
- **`<link rel="canonical">`** → collapses `?tag=`/embed/preview duplicates down to the canonical URL.
- **Full Open Graph**: `og:type=article`, `og:url`, `og:site_name`, `og:title`, `og:description`, `og:image`, `og:locale`, `article:published_time`, `article:author`, `article:tag`.
- **Twitter cards** (`summary_large_image`) so X/LinkedIn/Slack unfurls stop falling back to raw URLs.
- **JSON-LD** — `BlogPosting` (headline, author, datePublished, image, publisher, mainEntityOfPage, keywords) for posts, `WebSite` for the home. This is the single biggest signal Google rich results and LLM crawlers weight.
- **Fixes the hardcoded `bank.engineering` domain** in `og:image` URLs → now `blog.hcb.hackclub.com` with `/og-v1.png` as fallback when a post has no `primaryImage`.
- Also removes a stray `console.log("FOOBAR", post.meta.primaryImage)` in the post page.

**Why a shared component rather than inline `<Head>` per page?** One source of truth means future additions (e.g. a new OG property, a Twitter handle change) are a one-line edit, and all page types get consistent output by construction.

### 2 · `e9bc6c2` Add `robots.txt`, dynamic `sitemap.xml`, and `llms.txt`
`public/robots.txt` (new), `pages/sitemap.xml.js` (new), `pages/llms.txt.js` (new)

Discovery surface in three small files:

- **`robots.txt`** — allows everything by default, disallows utility paths (`/api/`, `/embed`, `/preview/`, `/widget`, `/dev/`), and explicitly allows major LLM crawlers (**GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, Claude-Web, anthropic-ai, PerplexityBot, Google-Extended, CCBot, Applebot-Extended**). Points at the sitemap via a `Sitemap:` line.
- **`sitemap.xml`** — dynamic via `getServerSideProps`, generated from the `posts` collection at request time. Each entry gets `<lastmod>` from the post's `meta.date` (ISO 8601); the root URL's `<lastmod>` is set to the most-recent post. URL values are escaped defensively. Cached at the edge (`s-maxage=3600, stale-while-revalidate=86400`) so the runtime cost is effectively zero.
- **`llms.txt`** — follows the emerging [llmstxt.org](https://llmstxt.org/) convention: a plain-text markdown index that LLM-powered tools (Claude Web, ChatGPT browsing, Perplexity) read to discover a site's content without parsing HTML. Lists every post with title, URL, and description (when present).

**Why SSR rather than a static `public/sitemap.xml`?** Because the `posts` collection is rebuilt every build from `content/posts/`, a dynamic route stays correct without anyone having to remember to regenerate a file.

### 3 · `8be06f9` Noindex utility pages
`pages/embed.js`, `pages/preview/[slug].js`, `pages/widget.js`, `pages/dev/dashboard.js`

Four routes render duplicate or thin-content versions of real posts for non-reader audiences:

- `/embed` — iframe teaser used on external pages
- `/widget` — tiny "unread count" badge
- `/preview/[slug]` — iframe preview inside the HCB app
- `/dev/dashboard` — internal content-audit dashboard

If a search engine or LLM crawler indexes these, they compete with the real `/posts/[slug]` pages and create duplicate-content confusion. `/embed` and `/preview/[slug]` now use `<Seo noindex>`; `/widget` and `/dev/dashboard` add `<meta name="robots" content="noindex,nofollow">` directly in their existing `<Head>` (they don't need the full SEO surface).

**Why both `robots.txt` + in-page `<meta>`?** `robots.txt` only discourages crawling; the meta tag ensures any already-indexed copies are de-indexed on the next crawl. Belt and suspenders.

Also removes the matching `console.log("FOOBAR", …)` from `/preview/[slug]`.

### 4 · `d4ec0f5` Promote post title to `<h1>`
`components/Header.js`

Post detail pages previously had no `<h1>` anywhere on the page — the sticky header rendered the post title as `<h2>`, and the post body (in `display='detail'` mode) doesn't emit its own title heading. The document outline therefore went straight from navigation `<h2>`s to in-content `<h2>`/`<h3>`s with nothing at the top of the tree.

Google and every major LLM rank the `<h1>` as the most semantically important heading on a page, and assistive tech uses it to announce "what this page is". One-line change: `as="h2"` → `as="h1"` in the branch of `Header.js` used when a `post` prop is passed. The home page still has its single `<h1>HCB Blog</h1>`, so no duplicate.

### 5 · `5994038` Publish every post as `/posts/<slug>.md`
`prebuild.js`, `.gitignore`, `components/Seo.js`, `pages/llms.txt.js`

LLMs pay a 3-5× context-window tax parsing rendered HTML vs. the underlying markdown. The emerging convention (Anthropic docs, Mintlify, Vercel's blog, Supabase, …) is to expose a `.md` twin for every page so LLM-powered tools can ingest content natively. Paired with `llms.txt`, this makes every post trivially retrievable in its cleanest form.

`prebuild.js` gains a `buildMarkdown()` step that runs alongside the existing posts-cache generation:

- Pulls metadata from `post({...})` via regex → YAML frontmatter (`title`, `slug`, `date`, `category`, `authors`, `tags`, `description`, `canonical`).
- Strips all `import` statements and the `export default post({…})` wrapper.
- Rewrites `<Image src={identifier} alt="…">` (where the identifier maps to a local `./file.png` import) into standard markdown, copying the asset to `public/posts/<slug>/<file>` so it resolves on the same origin.
- Leaves other JSX (`<video>`, `<table>`, `<Preview>`, `<Author>`) intact — LLMs parse it fine, and hand-rolled conversions would add risk for no meaningful gain.
- Wipes `public/posts/` on every run so deleted posts never leave ghost files behind.

Companion tweaks:

- `.gitignore` excludes `public/posts/` (matches how `.posts-cache.js` is handled).
- `Seo.js` emits `<link rel="alternate" type="text/markdown" href="/posts/<slug>.md">` on post pages so browsers and crawlers auto-discover the variant.
- `llms.txt` now points at `.md` URLs rather than HTML.

**Why regex rather than a real MDX parser?** The `post({...})` shape is narrow and convention-driven (enforced by `components/Post.js`'s JSDoc `PostMeta` type), the one-time fields we need are all primitives, and pulling in an MDX/AST dependency would dwarf the benefit. All 123 posts generate cleanly; the few with non-extractable fields (e.g. `cover: identifier` referencing a variable) just omit those frontmatter entries.

**Why copy images rather than serve them dynamically?** Static files under `/public` are served by the CDN with zero per-request compute and no build-config gymnastics (`outputFileTracing` etc.). The one cost is disk duplication (~134 MB in this run — most of it Headway screenshots that already exist under `content/posts/`). If that becomes a CI/deploy burden, a `pages/posts/[slug]/[file].js` handler reading from `content/posts/` on the fly is a drop-in swap — noted as a future option.

**Why does `/posts/<slug>.md` route cleanly?** Next.js public files take precedence over pages. `/posts/foo` still hits the dynamic `[slug].js` route (HTML); `/posts/foo.md` hits the generated static file. No routing config required.

## Verification

- `node prebuild.js --build` locally: 123 posts → 123 `.md` files written, 60 asset directories populated. Sampled output from newsletter/experiment/changelog posts all look clean (see `public/posts/newsletter-2024-december.md`, `public/posts/autofill.md`, `public/posts/zoom-around-hcb-with-the-command-bar-296910.md`).
- No dependencies were changed; no framework upgrades.
- Commits are organized so each fix can be reviewed (or reverted) independently.

## Not in this PR (intentional)

- **Per-post `description` backfill** — only 11/123 posts set `description`. The `Seo` component falls back gracefully, but filling these in would be a content task rather than a code change.
- **Per-post `primaryImage`** — only 3/123 set one. Same reasoning; `og-v1.png` is the fallback.
- **LLM bot allowlist breadth** — I erred on the side of including major crawlers. If the team prefers to block any of them (e.g. `CCBot`), it's a one-line edit in `robots.txt`.
- **Dynamic asset serving** — `public/posts/*` duplication is the simpler path; dynamic file serving is noted above as a future option if needed.
- **Dependency vulnerabilities** — GitHub flagged 30 on the default branch; those are out of scope for an SEO PR.
